### PR TITLE
feat(retry): `retries` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,14 @@ import { retry } from "promise-toolbox";
       },
 
       // number of tries including the first one, default to 10
+      //
+      // cannot be used with `retries`
       tries: 3,
+
+      // number of retries (excluding the initial run), default to undefined
+      //
+      // cannot be used with `tries`
+      retries: 4,
 
       // predicate when to retry, default on always but programmer errors
       // (ReferenceError, SyntaxError and TypeError)

--- a/src/retry.js
+++ b/src/retry.js
@@ -9,8 +9,14 @@ function stopRetry(error) {
 
 module.exports = function retry(
   fn,
-  { delay = 1e3, onRetry = noop, tries = 10, when } = {}
+  { delay = 1e3, onRetry = noop, retries, tries, when } = {}
 ) {
+  if (tries === undefined) {
+    tries = retries !== undefined ? retries + 1 : 10;
+  } else if (retries !== undefined) {
+    throw new TypeError("retries and tries options are mutually exclusive");
+  }
+
   const container = { error: undefined };
   const stop = stopRetry.bind(container);
 

--- a/src/retry.spec.js
+++ b/src/retry.spec.js
@@ -57,6 +57,19 @@ describe("retry()", () => {
     expect(i).toBe(1);
   });
 
+  describe("`tries` and `retries` options", () => {
+    it("are mutually exclusive", () => {
+      expect(() =>
+        retry(() => {}, {
+          tries: 3,
+          retries: 4,
+        })
+      ).toThrow(
+        new RangeError("retries and tries options are mutually exclusive")
+      );
+    });
+  });
+
   describe("`when` option", () => {
     forOwn(
       {


### PR DESCRIPTION
It is the same as `tries - 1` but can be easier to reason about in certain situation.

These options are mutually exclusive.