### PR TITLE
fix(nodeify): function never resolving

### DIFF
--- a/src/nodeify.js
+++ b/src/nodeify.js
@@ -1,4 +1,5 @@
 const setFunctionNameAndLength = require("./_setFunctionNameAndLength");
+const wrapApply = require('./wrapApply');
 
 const { slice } = Array.prototype;
 
@@ -11,7 +12,7 @@ const nodeify = fn =>
         throw new TypeError("missing callback");
       }
       const args = slice.call(arguments, 0, last);
-      fn.apply(this, args).then(
+      wrapApply(fn, args).then(
         value => cb(undefined, value),
         cb
       );

--- a/src/nodeify.js
+++ b/src/nodeify.js
@@ -11,7 +11,7 @@ const nodeify = fn =>
         throw new TypeError("missing callback");
       }
       const args = slice.call(arguments, 0, last);
-      new Promise(resolve => fn.apply(this, args)).then(
+      fn.apply(this, args).then(
         value => cb(undefined, value),
         cb
       );

--- a/src/nodeify.spec.js
+++ b/src/nodeify.spec.js
@@ -1,0 +1,50 @@
+/* eslint-env jest */
+
+const nodeify = require("./nodeify");
+
+describe("nodeify()", () => {
+  it("handles resolved promises", done => {
+    nodeify(() => Promise.resolve("foo"))((err, res) => {
+      expect(err).toBe(undefined);
+      expect(res).toBe("foo");
+      done();
+    });
+  });
+
+  it("handles rejected promises", done => {
+    const err = new Error();
+    nodeify(() => Promise.reject(err))((err, res) => {
+      expect(err).toBe(err);
+      expect(res).toBe(undefined);
+      done();
+    });
+  });
+
+  it("handles sync calls values", done => {
+    nodeify(() => "foo")((err, res) => {
+      expect(err).toBe(undefined);
+      expect(res).toBe("foo");
+      done();
+    });
+  });
+
+  it("handles thrown errors", done => {
+    const error = new Error();
+    nodeify(() => {
+      throw error;
+    })((err, res) => {
+      expect(err).toBe(err);
+      expect(res).toBe(undefined);
+      done();
+    });
+  });
+
+  it("returns a function with the same name", () => {
+    function foo() {}
+    expect(nodeify(foo).name).toBe(foo.name);
+  });
+
+  it("returns a function with one more param", () => {
+    expect(nodeify(function(a, b) {}).length).toBe(3);
+  });
+});


### PR DESCRIPTION
`nodeify` was not working because `new Promise` was never fulfilling (`resolve` was not getting called). Since we assume that `fn` returns a `Promise`, this can be fixed by simplifying the implementation